### PR TITLE
Allow for signing with a different URL than the one you are fetching from

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -68,13 +68,22 @@ export class AwsClient {
 }
 
 export class AwsV4Signer {
-  constructor({ method, url, headers, body, accessKeyId, secretAccessKey, sessionToken, service, region, cache, datetime, signQuery, appendSessionToken, allHeaders, singleEncode }) {
+  constructor({ method, url, proxyTo = null, headers, body, accessKeyId, secretAccessKey, sessionToken, service, region, cache, datetime, signQuery, appendSessionToken, allHeaders, singleEncode }) {
     if (url == null) throw new TypeError('url is a required option')
     if (accessKeyId == null) throw new TypeError('accessKeyId is a required option')
     if (secretAccessKey == null) throw new TypeError('secretAccessKey is a required option')
 
     this.method = method || (body ? 'POST' : 'GET')
-    this.url = new URL(url)
+    
+    // if `proxyTo` is present, sign with the destination URL
+    if (proxyTo) {
+      this.url = new URL(proxyTo)
+    } else {
+      this.url = new URL(url)
+    }
+    // where the actual fetch request will be made
+    this.fetchUrl = new URL(url)
+
     this.headers = new Headers(headers)
     this.body = body
 
@@ -163,7 +172,7 @@ export class AwsV4Signer {
 
     return {
       method: this.method,
-      url: this.url,
+      url: this.fetchUrl,
       headers: this.headers,
       body: this.body,
     }


### PR DESCRIPTION
Creating this PR mainly to open a discussion around whether or not anyone else might find this feature useful. Basically, I'm using `http-proxy-middleware` in order to proxy requests in my app to various services. One of these services requires a signed AWS4 request, but in my case, I actually want the `fetch` to proxy through my `http-proxy-middleware` server. 

**What changed**

Add an optional `proxyTo` param that represents where the actual request will be made, allowing you to separate out the `fetch` call and the downstream request that needs to be signed with a valid `host`

**Usage**
```javascript
const awsClient = new AwsClient({ ... })
const result = await awsClient.fetch('https://localhost:3001/api/books', { method: 'GET', proxyTo: 'https://some.prod.service/api/books')
```
In this case, the client will sign the request with the downstream host, but make the actual fetch request to your local server. 

This may be dumb, or insecure, but my knowledge of AWS4 / signing requests is limited. Happy to hear any feedback.