### PR TITLE
Added Range to Unsignable Headers

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -21,6 +21,7 @@ const UNSIGNABLE_HEADERS = [
   'presigned-expires',
   'expect',
   'x-amzn-trace-id',
+  'range',
 ]
 
 export class AwsClient {


### PR DESCRIPTION
Developers using [Cloudflare Workers](https://workers.cloudflare.com/) (Service Workers running on our global edge network) rely on this library to sign requests to Amazon S3.

CDNs such as Cloudflare often manipulate or strip the Range Header to optimise/reduce the cost how content is pulled from S3. This behaviour is important because the Range header can take arbitrary, high-cardinality values. If CDNs don't do this then cache hit rates will be very poor leading to increased latency and cost fetching data directly from S3.

This pull request includes Range as an Unsignable Header so the signature can be used by a CDN to fetch the full object or normalised byte ranges, improving performance and reducing cost of serving content from S3. 