### PR TITLE
Added personalize-runtime host to HOST_SERVICES

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ const HOST_SERVICES = {
   'mturk-requester-sandbox': 'mturk-requester',
   'pinpoint': 'mobiletargeting',
   'queue': 'sqs',
+  'personalize-runtime': 'personalize',
 }
 
 // https://github.com/aws/aws-sdk-js/blob/cc29728c1c4178969ebabe3bbe6b6f3159436394/lib/signers/v4.js#L190-L198


### PR DESCRIPTION
`personalize-runtime` requests should be signed as `personalize` service. AWS Personalize endpoints: https://docs.aws.amazon.com/general/latest/gr/personalize.html

This fixes the problem of «Credential should be scoped to correct service: 'personalize'.» when requesting `personalize-runtime`.