### PR TITLE
Added logic for checking crypto module in browser environments (fix ReferenceError: crypto is not defined)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,14 @@
 
 const encoder = new TextEncoder()
 
+const getCrypto = () => {
+  // cloudflare env
+  if (typeof crypto !== "undefined") return crypto
+  // browser env
+  if (typeof window !== "undefined" && window.crypto) return window.crypto
+  throw new Error("window.crypto is not defined, browser is not supported!")
+}
+
 /** @type {Object.<string, string>} */
 const HOST_SERVICES = {
   appstream2: 'appstream',
@@ -332,14 +340,14 @@ export class AwsV4Signer {
  */
 async function hmac(key, string) {
   // @ts-ignore // https://github.com/microsoft/TypeScript/issues/38715
-  const cryptoKey = await crypto.subtle.importKey(
+  const cryptoKey = await getCrypto().subtle.importKey(
     'raw',
     typeof key === 'string' ? encoder.encode(key) : key,
     { name: 'HMAC', hash: { name: 'SHA-256' } },
     false,
     ['sign'],
   )
-  return crypto.subtle.sign('HMAC', cryptoKey, encoder.encode(string))
+  return getCrypto().subtle.sign('HMAC', cryptoKey, encoder.encode(string))
 }
 
 /**
@@ -348,7 +356,7 @@ async function hmac(key, string) {
  */
 async function hash(content) {
   // @ts-ignore // https://github.com/microsoft/TypeScript/issues/38715
-  return crypto.subtle.digest('SHA-256', typeof content === 'string' ? encoder.encode(content) : content)
+  return getCrypto().subtle.digest('SHA-256', typeof content === 'string' ? encoder.encode(content) : content)
 }
 
 /**


### PR DESCRIPTION
I use ObservableHQ which executes npm modules in a browser, but for some reason this package was failing because when it was required, it wasn't detecting the globally scoped "crypto" module. I believe best practice is to check the `window` object for the crypto module, rather than assuming it is in global scope, but I understand Cloudflare may not define the window object. As an added bonus I've added an error message when crypto isn't found.

I published my work under `@seveibar/aws4fetch` to allow my integration with the [Universal Data Tool](https://github.com/UniversalDataTool/universal-data-tool) to continue.

Thanks @mhart for publishing your helpful and very clean work on this module. I understand the code addition is a bit smelly relative to the rest of the module, happy to refactor if given direction.

![Screen Capture_select-area_20200811214102](https://user-images.githubusercontent.com/1910070/89966336-ea84fb00-dc1c-11ea-957b-719ea1fd5828.png)
