### PR TITLE
feat: support injecting globals for supporting platforms that do not have whatwg fetch as globals (e.g. Node.js)

### DIFF
--- a/dist/aws4fetch.cjs.js
+++ b/dist/aws4fetch.cjs.js
@@ -6,7 +6,6 @@ Object.defineProperty(exports, '__esModule', { value: true });
  * @license MIT <https://opensource.org/licenses/MIT>
  * @copyright Michael Hart 2022
  */
-const encoder = new TextEncoder();
 const HOST_SERVICES = {
   appstream2: 'appstream',
   cloudhsmv2: 'cloudhsm',
@@ -18,6 +17,13 @@ const HOST_SERVICES = {
   'git-codecommit': 'codecommit',
   'mturk-requester-sandbox': 'mturk-requester',
   'personalize-runtime': 'personalize',
+};
+const DEFAULT_API = {
+  fetch: globalThis.fetch,
+  Request: globalThis.Request,
+  Headers: globalThis.Headers,
+  crypto: globalThis.crypto,
+  TextEncoder: globalThis.TextEncoder,
 };
 const UNSIGNABLE_HEADERS = new Set([
   'authorization',
@@ -31,7 +37,7 @@ const UNSIGNABLE_HEADERS = new Set([
   'connection',
 ]);
 class AwsClient {
-  constructor({ accessKeyId, secretAccessKey, sessionToken, service, region, cache, retries, initRetryMs }) {
+  constructor({ accessKeyId, secretAccessKey, sessionToken, service, region, cache, retries, initRetryMs, api }) {
     if (accessKeyId == null) throw new TypeError('accessKeyId is a required option')
     if (secretAccessKey == null) throw new TypeError('secretAccessKey is a required option')
     this.accessKeyId = accessKeyId;
@@ -42,9 +48,11 @@ class AwsClient {
     this.cache = cache || new Map();
     this.retries = retries != null ? retries : 10;
     this.initRetryMs = initRetryMs || 50;
+    this.api = api || DEFAULT_API;
+    this.textEncoder = new this.api.TextEncoder();
   }
   async sign(input, init) {
-    if (input instanceof Request) {
+    if (input instanceof this.api.Request) {
       const { method, url, headers, body } = input;
       init = Object.assign({ method, url, headers }, init);
       if (init.body == null && headers.has('Content-Type')) {
@@ -52,21 +60,21 @@ class AwsClient {
       }
       input = url;
     }
-    const signer = new AwsV4Signer(Object.assign({ url: input }, init, this, init && init.aws));
+    const signer = new AwsV4Signer(Object.assign({ url: input, api: this.api, textEncoder: this.textEncoder }, init, this, init && init.aws));
     const signed = Object.assign({}, init, await signer.sign());
     delete signed.aws;
     try {
-      return new Request(signed.url.toString(), signed)
+      return new this.api.Request(signed.url.toString(), signed)
     } catch (e) {
       if (e instanceof TypeError) {
-        return new Request(signed.url.toString(), Object.assign({ duplex: 'half' }, signed))
+        return new this.api.Request(signed.url.toString(), Object.assign({ duplex: 'half' }, signed))
       }
       throw e
     }
   }
   async fetch(input, init) {
     for (let i = 0; i <= this.retries; i++) {
-      const fetched = fetch(await this.sign(input, init));
+      const fetched = this.api.fetch(await this.sign(input, init));
       if (i === this.retries) {
         return fetched
       }
@@ -80,13 +88,15 @@ class AwsClient {
   }
 }
 class AwsV4Signer {
-  constructor({ method, url, headers, body, accessKeyId, secretAccessKey, sessionToken, service, region, cache, datetime, signQuery, appendSessionToken, allHeaders, singleEncode }) {
+  constructor({ method, url, headers, body, accessKeyId, secretAccessKey, sessionToken, service, region, cache, datetime, signQuery, appendSessionToken, allHeaders, singleEncode, api, textEncoder }) {
     if (url == null) throw new TypeError('url is a required option')
     if (accessKeyId == null) throw new TypeError('accessKeyId is a required option')
     if (secretAccessKey == null) throw new TypeError('secretAccessKey is a required option')
+    this.api = api ?? DEFAULT_API;
+    this.textEncoder = textEncoder || new DEFAULT_API.TextEncoder();
     this.method = method || (body ? 'POST' : 'GET');
     this.url = new URL(url);
-    this.headers = new Headers(headers || {});
+    this.headers = new this.api.Headers(headers || {});
     this.body = body;
     this.accessKeyId = accessKeyId;
     this.secretAccessKey = secretAccessKey;
@@ -182,20 +192,20 @@ class AwsV4Signer {
     const cacheKey = [this.secretAccessKey, date, this.region, this.service].join();
     let kCredentials = this.cache.get(cacheKey);
     if (!kCredentials) {
-      const kDate = await hmac('AWS4' + this.secretAccessKey, date);
-      const kRegion = await hmac(kDate, this.region);
-      const kService = await hmac(kRegion, this.service);
-      kCredentials = await hmac(kService, 'aws4_request');
+      const kDate = await hmac(this.api.crypto, this.textEncoder, 'AWS4' + this.secretAccessKey, date);
+      const kRegion = await hmac(this.api.crypto, this.textEncoder, kDate, this.region);
+      const kService = await hmac(this.api.crypto, this.textEncoder, kRegion, this.service);
+      kCredentials = await hmac(this.api.crypto, this.textEncoder, kService, 'aws4_request');
       this.cache.set(cacheKey, kCredentials);
     }
-    return buf2hex(await hmac(kCredentials, await this.stringToSign()))
+    return buf2hex(await hmac(this.api.crypto, this.textEncoder, kCredentials, await this.stringToSign()))
   }
   async stringToSign() {
     return [
       'AWS4-HMAC-SHA256',
       this.datetime,
       this.credentialString,
-      buf2hex(await hash(await this.canonicalString())),
+      buf2hex(await hash(this.api.crypto, this.textEncoder, await this.canonicalString())),
     ].join('\n')
   }
   async canonicalString() {
@@ -214,12 +224,12 @@ class AwsV4Signer {
       if (this.body && typeof this.body !== 'string' && !('byteLength' in this.body)) {
         throw new Error('body must be a string, ArrayBuffer or ArrayBufferView, unless you include the X-Amz-Content-Sha256 header')
       }
-      hashHeader = buf2hex(await hash(this.body || ''));
+      hashHeader = buf2hex(await hash(this.api.crypto, this.textEncoder, this.body || ''));
     }
     return hashHeader
   }
 }
-async function hmac(key, string) {
+async function hmac(crypto, encoder, key, string) {
   const cryptoKey = await crypto.subtle.importKey(
     'raw',
     typeof key === 'string' ? encoder.encode(key) : key,
@@ -229,7 +239,7 @@ async function hmac(key, string) {
   );
   return crypto.subtle.sign('HMAC', cryptoKey, encoder.encode(string))
 }
-async function hash(content) {
+async function hash(crypto, encoder, content) {
   return crypto.subtle.digest('SHA-256', typeof content === 'string' ? encoder.encode(content) : content)
 }
 function buf2hex(buffer) {

--- a/dist/aws4fetch.esm.js
+++ b/dist/aws4fetch.esm.js
@@ -2,7 +2,6 @@
  * @license MIT <https://opensource.org/licenses/MIT>
  * @copyright Michael Hart 2022
  */
-const encoder = new TextEncoder();
 const HOST_SERVICES = {
   appstream2: 'appstream',
   cloudhsmv2: 'cloudhsm',
@@ -14,6 +13,13 @@ const HOST_SERVICES = {
   'git-codecommit': 'codecommit',
   'mturk-requester-sandbox': 'mturk-requester',
   'personalize-runtime': 'personalize',
+};
+const DEFAULT_API = {
+  fetch: globalThis.fetch,
+  Request: globalThis.Request,
+  Headers: globalThis.Headers,
+  crypto: globalThis.crypto,
+  TextEncoder: globalThis.TextEncoder,
 };
 const UNSIGNABLE_HEADERS = new Set([
   'authorization',
@@ -27,7 +33,7 @@ const UNSIGNABLE_HEADERS = new Set([
   'connection',
 ]);
 class AwsClient {
-  constructor({ accessKeyId, secretAccessKey, sessionToken, service, region, cache, retries, initRetryMs }) {
+  constructor({ accessKeyId, secretAccessKey, sessionToken, service, region, cache, retries, initRetryMs, api }) {
     if (accessKeyId == null) throw new TypeError('accessKeyId is a required option')
     if (secretAccessKey == null) throw new TypeError('secretAccessKey is a required option')
     this.accessKeyId = accessKeyId;
@@ -38,9 +44,11 @@ class AwsClient {
     this.cache = cache || new Map();
     this.retries = retries != null ? retries : 10;
     this.initRetryMs = initRetryMs || 50;
+    this.api = api || DEFAULT_API;
+    this.textEncoder = new this.api.TextEncoder();
   }
   async sign(input, init) {
-    if (input instanceof Request) {
+    if (input instanceof this.api.Request) {
       const { method, url, headers, body } = input;
       init = Object.assign({ method, url, headers }, init);
       if (init.body == null && headers.has('Content-Type')) {
@@ -48,21 +56,21 @@ class AwsClient {
       }
       input = url;
     }
-    const signer = new AwsV4Signer(Object.assign({ url: input }, init, this, init && init.aws));
+    const signer = new AwsV4Signer(Object.assign({ url: input, api: this.api, textEncoder: this.textEncoder }, init, this, init && init.aws));
     const signed = Object.assign({}, init, await signer.sign());
     delete signed.aws;
     try {
-      return new Request(signed.url.toString(), signed)
+      return new this.api.Request(signed.url.toString(), signed)
     } catch (e) {
       if (e instanceof TypeError) {
-        return new Request(signed.url.toString(), Object.assign({ duplex: 'half' }, signed))
+        return new this.api.Request(signed.url.toString(), Object.assign({ duplex: 'half' }, signed))
       }
       throw e
     }
   }
   async fetch(input, init) {
     for (let i = 0; i <= this.retries; i++) {
-      const fetched = fetch(await this.sign(input, init));
+      const fetched = this.api.fetch(await this.sign(input, init));
       if (i === this.retries) {
         return fetched
       }
@@ -76,13 +84,15 @@ class AwsClient {
   }
 }
 class AwsV4Signer {
-  constructor({ method, url, headers, body, accessKeyId, secretAccessKey, sessionToken, service, region, cache, datetime, signQuery, appendSessionToken, allHeaders, singleEncode }) {
+  constructor({ method, url, headers, body, accessKeyId, secretAccessKey, sessionToken, service, region, cache, datetime, signQuery, appendSessionToken, allHeaders, singleEncode, api, textEncoder }) {
     if (url == null) throw new TypeError('url is a required option')
     if (accessKeyId == null) throw new TypeError('accessKeyId is a required option')
     if (secretAccessKey == null) throw new TypeError('secretAccessKey is a required option')
+    this.api = api ?? DEFAULT_API;
+    this.textEncoder = textEncoder || new DEFAULT_API.TextEncoder();
     this.method = method || (body ? 'POST' : 'GET');
     this.url = new URL(url);
-    this.headers = new Headers(headers || {});
+    this.headers = new this.api.Headers(headers || {});
     this.body = body;
     this.accessKeyId = accessKeyId;
     this.secretAccessKey = secretAccessKey;
@@ -178,20 +188,20 @@ class AwsV4Signer {
     const cacheKey = [this.secretAccessKey, date, this.region, this.service].join();
     let kCredentials = this.cache.get(cacheKey);
     if (!kCredentials) {
-      const kDate = await hmac('AWS4' + this.secretAccessKey, date);
-      const kRegion = await hmac(kDate, this.region);
-      const kService = await hmac(kRegion, this.service);
-      kCredentials = await hmac(kService, 'aws4_request');
+      const kDate = await hmac(this.api.crypto, this.textEncoder, 'AWS4' + this.secretAccessKey, date);
+      const kRegion = await hmac(this.api.crypto, this.textEncoder, kDate, this.region);
+      const kService = await hmac(this.api.crypto, this.textEncoder, kRegion, this.service);
+      kCredentials = await hmac(this.api.crypto, this.textEncoder, kService, 'aws4_request');
       this.cache.set(cacheKey, kCredentials);
     }
-    return buf2hex(await hmac(kCredentials, await this.stringToSign()))
+    return buf2hex(await hmac(this.api.crypto, this.textEncoder, kCredentials, await this.stringToSign()))
   }
   async stringToSign() {
     return [
       'AWS4-HMAC-SHA256',
       this.datetime,
       this.credentialString,
-      buf2hex(await hash(await this.canonicalString())),
+      buf2hex(await hash(this.api.crypto, this.textEncoder, await this.canonicalString())),
     ].join('\n')
   }
   async canonicalString() {
@@ -210,12 +220,12 @@ class AwsV4Signer {
       if (this.body && typeof this.body !== 'string' && !('byteLength' in this.body)) {
         throw new Error('body must be a string, ArrayBuffer or ArrayBufferView, unless you include the X-Amz-Content-Sha256 header')
       }
-      hashHeader = buf2hex(await hash(this.body || ''));
+      hashHeader = buf2hex(await hash(this.api.crypto, this.textEncoder, this.body || ''));
     }
     return hashHeader
   }
 }
-async function hmac(key, string) {
+async function hmac(crypto, encoder, key, string) {
   const cryptoKey = await crypto.subtle.importKey(
     'raw',
     typeof key === 'string' ? encoder.encode(key) : key,
@@ -225,7 +235,7 @@ async function hmac(key, string) {
   );
   return crypto.subtle.sign('HMAC', cryptoKey, encoder.encode(string))
 }
-async function hash(content) {
+async function hash(crypto, encoder, content) {
   return crypto.subtle.digest('SHA-256', typeof content === 'string' ? encoder.encode(content) : content)
 }
 function buf2hex(buffer) {

--- a/dist/aws4fetch.esm.mjs
+++ b/dist/aws4fetch.esm.mjs
@@ -2,7 +2,6 @@
  * @license MIT <https://opensource.org/licenses/MIT>
  * @copyright Michael Hart 2022
  */
-const encoder = new TextEncoder();
 const HOST_SERVICES = {
   appstream2: 'appstream',
   cloudhsmv2: 'cloudhsm',
@@ -14,6 +13,13 @@ const HOST_SERVICES = {
   'git-codecommit': 'codecommit',
   'mturk-requester-sandbox': 'mturk-requester',
   'personalize-runtime': 'personalize',
+};
+const DEFAULT_API = {
+  fetch: globalThis.fetch,
+  Request: globalThis.Request,
+  Headers: globalThis.Headers,
+  crypto: globalThis.crypto,
+  TextEncoder: globalThis.TextEncoder,
 };
 const UNSIGNABLE_HEADERS = new Set([
   'authorization',
@@ -27,7 +33,7 @@ const UNSIGNABLE_HEADERS = new Set([
   'connection',
 ]);
 class AwsClient {
-  constructor({ accessKeyId, secretAccessKey, sessionToken, service, region, cache, retries, initRetryMs }) {
+  constructor({ accessKeyId, secretAccessKey, sessionToken, service, region, cache, retries, initRetryMs, api }) {
     if (accessKeyId == null) throw new TypeError('accessKeyId is a required option')
     if (secretAccessKey == null) throw new TypeError('secretAccessKey is a required option')
     this.accessKeyId = accessKeyId;
@@ -38,9 +44,11 @@ class AwsClient {
     this.cache = cache || new Map();
     this.retries = retries != null ? retries : 10;
     this.initRetryMs = initRetryMs || 50;
+    this.api = api || DEFAULT_API;
+    this.textEncoder = new this.api.TextEncoder();
   }
   async sign(input, init) {
-    if (input instanceof Request) {
+    if (input instanceof this.api.Request) {
       const { method, url, headers, body } = input;
       init = Object.assign({ method, url, headers }, init);
       if (init.body == null && headers.has('Content-Type')) {
@@ -48,21 +56,21 @@ class AwsClient {
       }
       input = url;
     }
-    const signer = new AwsV4Signer(Object.assign({ url: input }, init, this, init && init.aws));
+    const signer = new AwsV4Signer(Object.assign({ url: input, api: this.api, textEncoder: this.textEncoder }, init, this, init && init.aws));
     const signed = Object.assign({}, init, await signer.sign());
     delete signed.aws;
     try {
-      return new Request(signed.url.toString(), signed)
+      return new this.api.Request(signed.url.toString(), signed)
     } catch (e) {
       if (e instanceof TypeError) {
-        return new Request(signed.url.toString(), Object.assign({ duplex: 'half' }, signed))
+        return new this.api.Request(signed.url.toString(), Object.assign({ duplex: 'half' }, signed))
       }
       throw e
     }
   }
   async fetch(input, init) {
     for (let i = 0; i <= this.retries; i++) {
-      const fetched = fetch(await this.sign(input, init));
+      const fetched = this.api.fetch(await this.sign(input, init));
       if (i === this.retries) {
         return fetched
       }
@@ -76,13 +84,15 @@ class AwsClient {
   }
 }
 class AwsV4Signer {
-  constructor({ method, url, headers, body, accessKeyId, secretAccessKey, sessionToken, service, region, cache, datetime, signQuery, appendSessionToken, allHeaders, singleEncode }) {
+  constructor({ method, url, headers, body, accessKeyId, secretAccessKey, sessionToken, service, region, cache, datetime, signQuery, appendSessionToken, allHeaders, singleEncode, api, textEncoder }) {
     if (url == null) throw new TypeError('url is a required option')
     if (accessKeyId == null) throw new TypeError('accessKeyId is a required option')
     if (secretAccessKey == null) throw new TypeError('secretAccessKey is a required option')
+    this.api = api ?? DEFAULT_API;
+    this.textEncoder = textEncoder || new DEFAULT_API.TextEncoder();
     this.method = method || (body ? 'POST' : 'GET');
     this.url = new URL(url);
-    this.headers = new Headers(headers || {});
+    this.headers = new this.api.Headers(headers || {});
     this.body = body;
     this.accessKeyId = accessKeyId;
     this.secretAccessKey = secretAccessKey;
@@ -178,20 +188,20 @@ class AwsV4Signer {
     const cacheKey = [this.secretAccessKey, date, this.region, this.service].join();
     let kCredentials = this.cache.get(cacheKey);
     if (!kCredentials) {
-      const kDate = await hmac('AWS4' + this.secretAccessKey, date);
-      const kRegion = await hmac(kDate, this.region);
-      const kService = await hmac(kRegion, this.service);
-      kCredentials = await hmac(kService, 'aws4_request');
+      const kDate = await hmac(this.api.crypto, this.textEncoder, 'AWS4' + this.secretAccessKey, date);
+      const kRegion = await hmac(this.api.crypto, this.textEncoder, kDate, this.region);
+      const kService = await hmac(this.api.crypto, this.textEncoder, kRegion, this.service);
+      kCredentials = await hmac(this.api.crypto, this.textEncoder, kService, 'aws4_request');
       this.cache.set(cacheKey, kCredentials);
     }
-    return buf2hex(await hmac(kCredentials, await this.stringToSign()))
+    return buf2hex(await hmac(this.api.crypto, this.textEncoder, kCredentials, await this.stringToSign()))
   }
   async stringToSign() {
     return [
       'AWS4-HMAC-SHA256',
       this.datetime,
       this.credentialString,
-      buf2hex(await hash(await this.canonicalString())),
+      buf2hex(await hash(this.api.crypto, this.textEncoder, await this.canonicalString())),
     ].join('\n')
   }
   async canonicalString() {
@@ -210,12 +220,12 @@ class AwsV4Signer {
       if (this.body && typeof this.body !== 'string' && !('byteLength' in this.body)) {
         throw new Error('body must be a string, ArrayBuffer or ArrayBufferView, unless you include the X-Amz-Content-Sha256 header')
       }
-      hashHeader = buf2hex(await hash(this.body || ''));
+      hashHeader = buf2hex(await hash(this.api.crypto, this.textEncoder, this.body || ''));
     }
     return hashHeader
   }
 }
-async function hmac(key, string) {
+async function hmac(crypto, encoder, key, string) {
   const cryptoKey = await crypto.subtle.importKey(
     'raw',
     typeof key === 'string' ? encoder.encode(key) : key,
@@ -225,7 +235,7 @@ async function hmac(key, string) {
   );
   return crypto.subtle.sign('HMAC', cryptoKey, encoder.encode(string))
 }
-async function hash(content) {
+async function hash(crypto, encoder, content) {
   return crypto.subtle.digest('SHA-256', typeof content === 'string' ? encoder.encode(content) : content)
 }
 function buf2hex(buffer) {

--- a/dist/main.d.ts
+++ b/dist/main.d.ts
@@ -1,5 +1,5 @@
 export class AwsClient {
-    constructor({ accessKeyId, secretAccessKey, sessionToken, service, region, cache, retries, initRetryMs }: {
+    constructor({ accessKeyId, secretAccessKey, sessionToken, service, region, cache, retries, initRetryMs, api }: {
         accessKeyId: string;
         secretAccessKey: string;
         sessionToken?: string;
@@ -8,6 +8,7 @@ export class AwsClient {
         cache?: Map<string, ArrayBuffer>;
         retries?: number;
         initRetryMs?: number;
+        api?: typeof DEFAULT_API;
     });
     accessKeyId: string;
     secretAccessKey: string;
@@ -17,6 +18,23 @@ export class AwsClient {
     cache: Map<any, any>;
     retries: number;
     initRetryMs: number;
+    api: {
+        fetch: typeof fetch;
+        Request: {
+            new (input: RequestInfo | URL, init?: RequestInit | undefined): Request;
+            prototype: Request;
+        };
+        Headers: {
+            new (init?: HeadersInit | undefined): Headers;
+            prototype: Headers;
+        };
+        crypto: Crypto;
+        TextEncoder: {
+            new (): TextEncoder;
+            prototype: TextEncoder;
+        };
+    };
+    textEncoder: TextEncoder;
     sign(input: RequestInfo, init?: (RequestInit & {
         aws?: {
             accessKeyId?: string | undefined;
@@ -49,7 +67,7 @@ export class AwsClient {
     }) | null | undefined): Promise<Response>;
 }
 export class AwsV4Signer {
-    constructor({ method, url, headers, body, accessKeyId, secretAccessKey, sessionToken, service, region, cache, datetime, signQuery, appendSessionToken, allHeaders, singleEncode }: {
+    constructor({ method, url, headers, body, accessKeyId, secretAccessKey, sessionToken, service, region, cache, datetime, signQuery, appendSessionToken, allHeaders, singleEncode, api, textEncoder }: {
         method?: string;
         url: string;
         headers?: HeadersInit;
@@ -65,7 +83,17 @@ export class AwsV4Signer {
         appendSessionToken?: boolean;
         allHeaders?: boolean;
         singleEncode?: boolean;
+        textEncoder?: TextEncoder;
+        api?: {
+            Headers: typeof Headers;
+            crypto: Crypto;
+        };
     });
+    api: {
+        Headers: typeof Headers;
+        crypto: Crypto;
+    };
+    textEncoder: TextEncoder;
     method: string;
     url: URL;
     headers: Headers;
@@ -97,3 +125,25 @@ export class AwsV4Signer {
     canonicalString(): Promise<string>;
     hexBodyHash(): Promise<string>;
 }
+declare namespace DEFAULT_API {
+    const fetch_1: typeof globalThis.fetch;
+    export { fetch_1 as fetch };
+    const Request_1: {
+        new (input: RequestInfo | URL, init?: RequestInit | undefined): Request;
+        prototype: Request;
+    };
+    export { Request_1 as Request };
+    const Headers_1: {
+        new (init?: HeadersInit | undefined): Headers;
+        prototype: Headers;
+    };
+    export { Headers_1 as Headers };
+    const crypto_1: Crypto;
+    export { crypto_1 as crypto };
+    const TextEncoder_1: {
+        new (): TextEncoder;
+        prototype: TextEncoder;
+    };
+    export { TextEncoder_1 as TextEncoder };
+}
+export {};

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "declaration": "tsc -p declaration.tsconfig.json",
-    "build": "npm run declaration && rollup -c",
+    "build": "npm run declaration && npx rollup -c",
     "prepare": "npm run build",
     "lint": "eslint --ext .js,.cjs,.mjs .",
     "format": "eslint --ext .js,.cjs,.mjs --fix .",


### PR DESCRIPTION
I came across this library while noticing that `@aws-sdk/s3-client` does not work on Cloudflare Workers. (https://github.com/aws/aws-sdk-js-v3/issues/3104)

I am writing isomorphic code that should work both on Cloudflare Worker runtimes and Node.js runtimes.
Currently, this library only supports Node.js by polyfilling globals, which is a practice I would love to avoid.

Instead, this PR adds new parameters for passing `fetch`, `Request`, `Headers`, `crypto`, and `TextEncoder`  implementations to the `AwsClient` and `AwsV4Signer` constructors.
____

Closes https://github.com/mhart/aws4fetch/issues/22