### PR TITLE
Add types export to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws4fetch",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "A compact AWS client for modern JS environments",
   "author": "Michael Hart <michael.hart.au@gmail.com> (https://github.com/mhart)",
   "license": "MIT",
@@ -14,7 +14,8 @@
       "worker": "./dist/aws4fetch.esm.js",
       "browser": "./dist/aws4fetch.umd.js",
       "require": "./dist/aws4fetch.cjs.js",
-      "default": "./dist/aws4fetch.umd.js"
+      "default": "./dist/aws4fetch.umd.js",
+      "types": "./dist/main.d.ts"
     }
   },
   "types": "dist/main.d.ts",


### PR DESCRIPTION
I needed to add this export to package.json in order get the library working properly with TypeScript 5.1.3 and a simple Vue application based off of `npm init vue@3.3.4`.

Without this change VSCode gives the following error when attempting to import the module.
```
Could not find a declaration file for module 'aws4fetch'. '/path/to/node_modules/aws4fetch/dist/aws4fetch.esm.mjs' implicitly has an 'any' type.
  There are types at '/path/to/node_modules/aws4fetch/dist/main.d.ts', but this result could not be resolved when respecting package.json "exports". The 'aws4fetch' library may need to update its package.json or typings.ts(7016)
```