### PR TITLE
Type path for each export

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,24 +11,24 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/aws4fetch.esm.mjs",
-        "types": "./dist/main.d.ts"
+        "types": "./dist/main.d.ts",
+        "default": "./dist/aws4fetch.esm.mjs"
       },
       "worker": {
-        "default": "./dist/aws4fetch.esm.js",
-        "types": "./dist/main.d.ts"
+        "types": "./dist/main.d.ts",
+        "default": "./dist/aws4fetch.esm.js"
       },
       "browser": {
-        "default": "./dist/aws4fetch.umd.js",
-        "types": "./dist/main.d.ts"
+        "types": "./dist/main.d.ts",
+        "default": "./dist/aws4fetch.umd.js"
       },
       "require": {
-        "default": "./dist/aws4fetch.cjs.js",
-        "types": "./dist/main.d.ts"
+        "types": "./dist/main.d.ts",
+        "default": "./dist/aws4fetch.cjs.js"
       },
       "default": {
-        "default": "./dist/aws4fetch.umd.js",
-        "types": "./dist/main.d.ts"
+        "types": "./dist/main.d.ts",
+        "default": "./dist/aws4fetch.umd.js"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -10,14 +10,28 @@
   "browser": "dist/aws4fetch.umd.js",
   "exports": {
     ".": {
-      "import": "./dist/aws4fetch.esm.mjs",
-      "worker": "./dist/aws4fetch.esm.js",
-      "browser": "./dist/aws4fetch.umd.js",
-      "require": "./dist/aws4fetch.cjs.js",
-      "default": "./dist/aws4fetch.umd.js"
+      "import": {
+        "default": "./dist/aws4fetch.esm.mjs",
+        "types": "./dist/main.d.ts"
+      },
+      "worker": {
+        "default": "./dist/aws4fetch.esm.js",
+        "types": "./dist/main.d.ts"
+      },
+      "browser": {
+        "default": "./dist/aws4fetch.umd.js",
+        "types": "./dist/main.d.ts"
+      },
+      "require": {
+        "default": "./dist/aws4fetch.cjs.js",
+        "types": "./dist/main.d.ts"
+      },
+      "default": {
+        "default": "./dist/aws4fetch.umd.js",
+        "types": "./dist/main.d.ts"
+      }
     }
   },
-  "types": "dist/main.d.ts",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
       }
     }
   },
+  "types": "./dist/main.d.ts",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
       }
     }
   },
-  "types": "./dist/main.d.ts",
+  "types": "dist/main.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Fix for https://github.com/mhart/aws4fetch/issues/57

See https://github.com/microsoft/TypeScript/issues/52363

feature in npm docs is here https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing

Note "types" field must be first. Every export needs an entry. The existing root "types" is left as is as a fallback for old TS compilers.