### PR TITLE
fix disturbed ReadableStream error

### DIFF
--- a/dist/aws4fetch.cjs.js
+++ b/dist/aws4fetch.cjs.js
@@ -53,16 +53,9 @@ class AwsClient {
       input = url;
     }
     const signer = new AwsV4Signer(Object.assign({ url: input }, init, this, init && init.aws));
-    const signed = Object.assign({}, init, await signer.sign());
+    const signed = Object.assign(signer.body instanceof ReadableStream ? { duplex: 'half' } : {}, init, await signer.sign());
     delete signed.aws;
-    try {
-      return new Request(signed.url.toString(), signed)
-    } catch (e) {
-      if (e instanceof TypeError) {
-        return new Request(signed.url.toString(), Object.assign({ duplex: 'half' }, signed))
-      }
-      throw e
-    }
+    return new Request(signed.url.toString(), signed)
   }
   async fetch(input, init) {
     for (let i = 0; i <= this.retries; i++) {

--- a/dist/aws4fetch.esm.js
+++ b/dist/aws4fetch.esm.js
@@ -49,16 +49,9 @@ class AwsClient {
       input = url;
     }
     const signer = new AwsV4Signer(Object.assign({ url: input }, init, this, init && init.aws));
-    const signed = Object.assign({}, init, await signer.sign());
+    const signed = Object.assign(signer.body instanceof ReadableStream ? { duplex: 'half' } : {}, init, await signer.sign());
     delete signed.aws;
-    try {
-      return new Request(signed.url.toString(), signed)
-    } catch (e) {
-      if (e instanceof TypeError) {
-        return new Request(signed.url.toString(), Object.assign({ duplex: 'half' }, signed))
-      }
-      throw e
-    }
+    return new Request(signed.url.toString(), signed)
   }
   async fetch(input, init) {
     for (let i = 0; i <= this.retries; i++) {

--- a/dist/aws4fetch.esm.mjs
+++ b/dist/aws4fetch.esm.mjs
@@ -49,16 +49,9 @@ class AwsClient {
       input = url;
     }
     const signer = new AwsV4Signer(Object.assign({ url: input }, init, this, init && init.aws));
-    const signed = Object.assign({}, init, await signer.sign());
+    const signed = Object.assign(signer.body instanceof ReadableStream ? { duplex: 'half' } : {}, init, await signer.sign());
     delete signed.aws;
-    try {
-      return new Request(signed.url.toString(), signed)
-    } catch (e) {
-      if (e instanceof TypeError) {
-        return new Request(signed.url.toString(), Object.assign({ duplex: 'half' }, signed))
-      }
-      throw e
-    }
+    return new Request(signed.url.toString(), signed)
   }
   async fetch(input, init) {
     for (let i = 0; i <= this.retries; i++) {

--- a/dist/aws4fetch.umd.js
+++ b/dist/aws4fetch.umd.js
@@ -55,16 +55,9 @@
         input = url;
       }
       const signer = new AwsV4Signer(Object.assign({ url: input }, init, this, init && init.aws));
-      const signed = Object.assign({}, init, await signer.sign());
+      const signed = Object.assign(signer.body instanceof ReadableStream ? { duplex: 'half' } : {}, init, await signer.sign());
       delete signed.aws;
-      try {
-        return new Request(signed.url.toString(), signed)
-      } catch (e) {
-        if (e instanceof TypeError) {
-          return new Request(signed.url.toString(), Object.assign({ duplex: 'half' }, signed))
-        }
-        throw e
-      }
+      return new Request(signed.url.toString(), signed)
     }
     async fetch(input, init) {
       for (let i = 0; i <= this.retries; i++) {

--- a/src/main.js
+++ b/src/main.js
@@ -91,17 +91,9 @@ export class AwsClient {
       input = url
     }
     const signer = new AwsV4Signer(Object.assign({ url: input }, init, this, init && init.aws))
-    const signed = Object.assign({}, init, await signer.sign())
+    const signed = Object.assign(signer.body instanceof ReadableStream ? { duplex: 'half' } : {}, init, await signer.sign())
     delete signed.aws
-    try {
-      return new Request(signed.url.toString(), signed)
-    } catch (e) {
-      if (e instanceof TypeError) {
-        // https://bugs.chromium.org/p/chromium/issues/detail?id=1360943
-        return new Request(signed.url.toString(), Object.assign({ duplex: 'half' }, signed))
-      }
-      throw e
-    }
+    return new Request(signed.url.toString(), signed)
   }
 
   /**


### PR DESCRIPTION
Fixes #52 

When using this in the Cloudflare Workers runtime, I noticed an error:
<img width="864" alt="Screenshot 2024-03-24 at 15 09 08" src="https://github.com/mhart/aws4fetch/assets/4791949/0f963190-ffd1-439b-8887-7cc19d059576">

The issue doesn't reliably reproduce, but given the error message I suspect that the first Request on line 55 in the screenshot is consuming some of the body ReadableStream, which causes it to then throw on line 58.

The fetch spec states that the duplex property must be set if the body is a ReadableStream:
<img width="1221" alt="Screenshot 2024-03-24 at 15 18 05" src="https://github.com/mhart/aws4fetch/assets/4791949/1eabc667-13f3-4bcc-a960-6253f2cfb4c1">

So I've adjusted the code to do this