### PR TITLE
Use `service=s3` by default for DigitalOcean and Linode

### DIFF
--- a/dist/aws4fetch.cjs.js
+++ b/dist/aws4fetch.cjs.js
@@ -259,6 +259,14 @@ function guessServiceRegion(url, headers) {
     const match = hostname.match(/^(?:[^.]{1,63}\.)?s3\.([^.]{1,63})\.backblazeb2\.com$/);
     return match != null ? ['s3', match[1] || ''] : ['', '']
   }
+  if (hostname.endsWith('.linodeobjects.com')) {
+    const match = hostname.match(/^(?:[^.]{1,63}\.)?([^.]{1,63})\.linodeobjects\.com$/);
+    return match != null ? ['s3', match[1] || ''] : ['', '']
+  }
+  if (hostname.endsWith('.digitaloceanspaces.com')) {
+    const match = hostname.match(/^(?:[^.]{1,63}\.)?([^.]{1,63})\.digitaloceanspaces\.com$/);
+    return match != null ? ['s3', match[1] || ''] : ['', '']
+  }
   const match = hostname.replace('dualstack.', '').match(/([^.]{1,63})\.(?:([^.]{0,63})\.)?amazonaws\.com(?:\.cn)?$/);
   let service = (match && match[1]) || '';
   let region = match && match[2];

--- a/dist/aws4fetch.esm.js
+++ b/dist/aws4fetch.esm.js
@@ -255,6 +255,14 @@ function guessServiceRegion(url, headers) {
     const match = hostname.match(/^(?:[^.]{1,63}\.)?s3\.([^.]{1,63})\.backblazeb2\.com$/);
     return match != null ? ['s3', match[1] || ''] : ['', '']
   }
+  if (hostname.endsWith('.linodeobjects.com')) {
+    const match = hostname.match(/^(?:[^.]{1,63}\.)?([^.]{1,63})\.linodeobjects\.com$/);
+    return match != null ? ['s3', match[1] || ''] : ['', '']
+  }
+  if (hostname.endsWith('.digitaloceanspaces.com')) {
+    const match = hostname.match(/^(?:[^.]{1,63}\.)?([^.]{1,63})\.digitaloceanspaces\.com$/);
+    return match != null ? ['s3', match[1] || ''] : ['', '']
+  }
   const match = hostname.replace('dualstack.', '').match(/([^.]{1,63})\.(?:([^.]{0,63})\.)?amazonaws\.com(?:\.cn)?$/);
   let service = (match && match[1]) || '';
   let region = match && match[2];

--- a/dist/aws4fetch.esm.mjs
+++ b/dist/aws4fetch.esm.mjs
@@ -255,6 +255,14 @@ function guessServiceRegion(url, headers) {
     const match = hostname.match(/^(?:[^.]{1,63}\.)?s3\.([^.]{1,63})\.backblazeb2\.com$/);
     return match != null ? ['s3', match[1] || ''] : ['', '']
   }
+  if (hostname.endsWith('.linodeobjects.com')) {
+    const match = hostname.match(/^(?:[^.]{1,63}\.)?([^.]{1,63})\.linodeobjects\.com$/);
+    return match != null ? ['s3', match[1] || ''] : ['', '']
+  }
+  if (hostname.endsWith('.digitaloceanspaces.com')) {
+    const match = hostname.match(/^(?:[^.]{1,63}\.)?([^.]{1,63})\.digitaloceanspaces\.com$/);
+    return match != null ? ['s3', match[1] || ''] : ['', '']
+  }
   const match = hostname.replace('dualstack.', '').match(/([^.]{1,63})\.(?:([^.]{0,63})\.)?amazonaws\.com(?:\.cn)?$/);
   let service = (match && match[1]) || '';
   let region = match && match[2];

--- a/dist/aws4fetch.umd.js
+++ b/dist/aws4fetch.umd.js
@@ -261,6 +261,14 @@
       const match = hostname.match(/^(?:[^.]{1,63}\.)?s3\.([^.]{1,63})\.backblazeb2\.com$/);
       return match != null ? ['s3', match[1] || ''] : ['', '']
     }
+    if (hostname.endsWith('.linodeobjects.com')) {
+      const match = hostname.match(/^(?:[^.]{1,63}\.)?([^.]{1,63})\.linodeobjects\.com$/);
+      return match != null ? ['s3', match[1] || ''] : ['', '']
+    }
+    if (hostname.endsWith('.digitaloceanspaces.com')) {
+      const match = hostname.match(/^(?:[^.]{1,63}\.)?([^.]{1,63})\.digitaloceanspaces\.com$/);
+      return match != null ? ['s3', match[1] || ''] : ['', '']
+    }
     const match = hostname.replace('dualstack.', '').match(/([^.]{1,63})\.(?:([^.]{0,63})\.)?amazonaws\.com(?:\.cn)?$/);
     let service = (match && match[1]) || '';
     let region = match && match[2];

--- a/src/main.js
+++ b/src/main.js
@@ -404,6 +404,14 @@ function guessServiceRegion(url, headers) {
     const match = hostname.match(/^(?:[^.]{1,63}\.)?s3\.([^.]{1,63})\.backblazeb2\.com$/)
     return match != null ? ['s3', match[1] || ''] : ['', '']
   }
+  if (hostname.endsWith('.linodeobjects.com')) {
+    const match = hostname.match(/^(?:[^.]{1,63}\.)?([^.]{1,63})\.linodeobjects\.com$/)
+    return match != null ? ['s3', match[1] || ''] : ['', '']
+  }
+  if (hostname.endsWith('.digitaloceanspaces.com')) {
+    const match = hostname.match(/^(?:[^.]{1,63}\.)?([^.]{1,63})\.digitaloceanspaces\.com$/)
+    return match != null ? ['s3', match[1] || ''] : ['', '']
+  }
   const match = hostname.replace('dualstack.', '').match(/([^.]{1,63})\.(?:([^.]{0,63})\.)?amazonaws\.com(?:\.cn)?$/)
   let service = (match && match[1]) || ''
   let region = match && match[2]

--- a/test/serviceTests.js
+++ b/test/serviceTests.js
@@ -77,6 +77,10 @@ aa-custom-bucket.s3.us-west-001.backblazeb2.com,s3,us-west-001
 s3.us-west-001.backblazeb2.com,s3,us-west-001
 12345678.r2.cloudflarestorage.com,s3,auto
 aa-custom-bucket.12345678.r2.cloudflarestorage.com,s3,auto
+my-repo.us-sea-1.linodeobjects.com,s3,us-sea-1
+us-sea-1.linodeobjects.com,s3,us-sea-1
+my-space.nyc3.digitaloceanspaces.com,s3,nyc3
+nyc3.digitaloceanspaces.com,s3,nyc3
 ibvt72cx3dkyksnw7jktvkwhme0legmv.lambda-url.us-east-1.on.aws,lambda,us-east-1
   `
   return csv.trim().split('\n').map(line => {


### PR DESCRIPTION
A few services expect `service=s3` when this is not currently inferred by aws4fetch, such that they don't work "by default":

- DigitalOcean Spaces: https://github.com/mhart/aws4fetch/issues/15
- Linode Object Storage: https://github.com/twilligon/git-lfs-s3-proxy/issues/10

This detects their hostnames (`*.digitaloceanspaces.com` and `*.linodeobjects.com`) and follows the existing pattern for R2 and B2 detection to set the `service` parameter. Also added test coverage for both providers with virtual-host and path-style URLs. I think this is all correct, LMK if it needs edits!